### PR TITLE
Add wildcard caveat to README flake8 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Currently checks can only be passed a single argument and must do the parsing
 of that themselves.
 
 flake8 obeys the configuration as per the
-[flake8 docs](http://flake8.readthedocs.org/en/latest/config.html)
+[flake8 docs](http://flake8.readthedocs.org/en/latest/config.html) but any
+path-related options will need to use wildcard patterns (e.g.
+`exclude=*/migrations/*` instead of `exclude=migrations`).
 
 Checks
 ------


### PR DESCRIPTION
Also convert the checks section of the README to a proper list (as I was going to put the clarification there before I noticed where you'd already mentioned it).
