### PR TITLE
Replace python3 compile action with 2to3 action

### DIFF
--- a/captainhook/checkers/python3.py
+++ b/captainhook/checkers/python3.py
@@ -10,7 +10,6 @@ def run():
     "Check to see if python files are py3 compatible"
     errors = []
     for py_file in python_files_for_commit():
-        b = bash('python3 -m py_compile {0}'.format(py_file))
-        if b.err:
-            errors.append(b.err.decode(encoding='UTF-8'))
+        b = bash('2to3 {file}'.format(file=py_file))
+        errors.append(b.output.decode(encoding='UTF-8'))
     return "\n".join(errors)


### PR DESCRIPTION
This PR makes the python3 checker run a 2to3 code analysis on python code about to be committed instead of compiling it as python3. The advantage being that you get a diff view of all the changes you should make before committing rather than the first compile error that the python3 interpreter hit.
