### PR TITLE
add a checker for frosted when you do not want flake8 #68

### DIFF
--- a/captainhook/checkers/frosted_checker.py
+++ b/captainhook/checkers/frosted_checker.py
@@ -1,0 +1,22 @@
+# # # # # # # # # # # # # #
+# CAPTAINHOOK IDENTIFIER  #
+# # # # # # # # # # # # # #
+from .utils import bash, filter_python_files
+
+DEFAULT = 'off'
+CHECK_NAME = 'frosted'
+NO_FROSTED_MSG = ("frosted is required for the frosted plugin.\n"
+                "`pip install frosted` or turn it off in your tox.ini file.")
+REQUIRED_FILES = ['tox.ini']
+
+
+def run(files, temp_folder):
+    "Check frosted errors in the code base."
+    try:
+        import frosted  # NOQA
+    except ImportError:
+        return NO_FROSTED_MSG
+
+    py_files = filter_python_files(files)
+
+    return bash('frosted {0}'.format(' '.join(py_files))).value()


### PR DESCRIPTION
when working with legacy code that is not pep8 compliant flake8 is a bit of a drag, frosted is used instead of pyflakes here.