### PR TITLE
Fix #81: typos in isort_checker errmsg and docstr.

### DIFF
--- a/captainhook/checkers/isort_checker.py
+++ b/captainhook/checkers/isort_checker.py
@@ -5,13 +5,13 @@ from .utils import bash, filter_python_files
 
 DEFAULT = 'off'
 CHECK_NAME = 'isort'
-NO_ISORT_MSG = ("isort is required for the flake8 plugin.\n"
+NO_ISORT_MSG = ("isort is required for the isort plugin.\n"
                 "`pip install isort` or turn it off in your tox.ini file.")
 REQUIRED_FILES = ['.editorconfig', '.isort.cfg', 'setup.cfg']
 
 
 def run(files, temp_folder):
-    "Check flake8 errors in the code base."
+    "Check isort errors in the code base."
     try:
         import isort  # NOQA
     except ImportError:


### PR DESCRIPTION
This fixes the typos I mentioned in issue #81.