### PR TITLE
Fix #86: Remove Py32 tox env.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ frosted:on
 exclude=features/*.py
 
 [tox]
-envlist = py27,py32,py34
+envlist = py27,py34
 
 [testenv]
 deps =


### PR DESCRIPTION
Also defines the PyPI version category to be 3.4.