### PR TITLE
Pylint checkers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,12 @@ Currently supported checks are
 - flake8: Runs flake8_ on staged files (checks for `PEP 8`_ compliance and
   syntax errors).
 
+- pylint: Runs pylint_ on staged files. You can specify level of threshold
+  in tox.ini as number from 0 to 10.
+
+- pylint_docstrings: Runs pylint_ to check only docstrings on staged files.
+  You can specify level of threshold in tox.ini as number from 0 to 10.
+
 - frosted: Runs frosted_ on staged files (checks for Python syntax errors).
 
 - ``grep``: Runs a single ``grep`` command on staged files, rejecting the
@@ -108,6 +114,7 @@ Currently supported checks are
   Expects ``python3`` and ``2to3-2.7`` to be in the current shell ``PATH``.
 
   .. _flake8: https://pypi.python.org/pypi/flake8
+  .. _pylint: http://www.pylint.org/
   .. _frosted: https://pypi.python.org/pypi/frosted
   .. _isort: https://pypi.python.org/pypi/isort
   .. _`PEP 8`: https://www.python.org/dev/peps/pep-0008/

--- a/captainhook/checkers/pylint_checker.py
+++ b/captainhook/checkers/pylint_checker.py
@@ -27,7 +27,7 @@ def run(files, temp_folder, arg=None):
         return False
 
     str_py_files = " ".join(py_files)
-    cmd = "pylint {0} | grep rated".format(str_py_files)
+    cmd = "pylint {0}".format(str_py_files)
     output = bash(cmd).value().decode('utf-8')
 
     if 'rated' not in output:

--- a/captainhook/checkers/pylint_checker.py
+++ b/captainhook/checkers/pylint_checker.py
@@ -13,7 +13,7 @@ SCORE = 85.0
 
 
 def run(files, temp_folder, arg=None):
-    "Check docstring coverage of the code base."
+    "Check coding convention of the code base."
     try:
         import pylint
     except ImportError:

--- a/captainhook/checkers/pylint_checker.py
+++ b/captainhook/checkers/pylint_checker.py
@@ -30,7 +30,7 @@ def run(files, temp_folder, arg=None):
 
     str_py_files = " ".join(py_files)
     cmd = "{0} {1}".format(PYLINT_CMD, str_py_files)
-    output = bash(cmd).value().decode('utf-8')
+    output = bash(cmd).value()
 
     if 'rated' not in output:
         return False

--- a/captainhook/checkers/pylint_checker.py
+++ b/captainhook/checkers/pylint_checker.py
@@ -29,7 +29,6 @@ def run(files, temp_folder, arg=None):
     str_py_files = " ".join(py_files)
     cmd = "pylint {0} | grep rated".format(str_py_files)
     output = bash(cmd).value().decode('utf-8')
-    output = output.split()
 
     if 'rated' not in output:
         return False

--- a/captainhook/checkers/pylint_checker.py
+++ b/captainhook/checkers/pylint_checker.py
@@ -1,0 +1,41 @@
+# # # # # # # # # # # # # #
+# CAPTAINHOOK IDENTIFIER  #
+# # # # # # # # # # # # # #
+import re
+from .utils import bash, filter_python_files
+
+
+DEFAULT = 'off'
+CHECK_NAME = 'pylint'
+NO_PYLINT_MSG = ("pylint is required for the pylint plugin.\n"
+                "`pip install pylint` or turn it off in your tox.ini file.")
+SCORE = 85.0
+
+
+def run(files, temp_folder, arg=None):
+    "Check docstring coverage of the code base."
+    try:
+        import pylint
+    except ImportError:
+        return NO_PYLINT_MSG
+
+    # set default level of threshold
+    arg = arg or SCORE
+
+    py_files = filter_python_files(files)
+    if not py_files:
+        return False
+
+    str_py_files = " ".join(py_files)
+    cmd = "pylint {0} | grep rated".format(str_py_files)
+    output = bash(cmd).value().decode('utf-8')
+    output = output.split()
+
+    if 'rated' not in output:
+        return False
+    score = float(re.search("(\d.\d\d)/10", output).group(1))
+    if score >= float(arg):
+        return False
+    return ("Pylint appreciated your code as {0},"
+        "required threshold is {1}".format(score, arg)
+        )

--- a/captainhook/checkers/pylint_checker.py
+++ b/captainhook/checkers/pylint_checker.py
@@ -7,8 +7,10 @@ from .utils import bash, filter_python_files
 
 DEFAULT = 'off'
 CHECK_NAME = 'pylint'
-NO_PYLINT_MSG = ("pylint is required for the pylint plugin.\n"
-                "`pip install pylint` or turn it off in your tox.ini file.")
+NO_PYLINT_MSG = ("pylint is required for the {0} plugin.\n"
+                "`pip install pylint` or turn it off in your tox.ini file.".format(CHECK_NAME))
+PYLINT_CMD = 'pylint'
+PYLINT_TARGET = 'code'
 SCORE = 85.0
 
 
@@ -27,7 +29,7 @@ def run(files, temp_folder, arg=None):
         return False
 
     str_py_files = " ".join(py_files)
-    cmd = "pylint {0}".format(str_py_files)
+    cmd = "{0} {1}".format(PYLINT_CMD, str_py_files)
     output = bash(cmd).value().decode('utf-8')
 
     if 'rated' not in output:
@@ -35,6 +37,6 @@ def run(files, temp_folder, arg=None):
     score = float(re.search("(\d.\d\d)/10", output).group(1))
     if score >= float(arg):
         return False
-    return ("Pylint appreciated your code as {0},"
-        "required threshold is {1}".format(score, arg)
+    return ("Pylint appreciated your {0} as {1},"
+        "required threshold is {2}".format(PYLINT_TARGET, score, arg)
         )

--- a/captainhook/checkers/pylint_docstrings_checker.py
+++ b/captainhook/checkers/pylint_docstrings_checker.py
@@ -27,7 +27,7 @@ def run(files, temp_folder, arg=None):
         return False
 
     str_py_files = " ".join(py_files)
-    cmd = "pylint -d all -e missing-docstring {0} | grep rated".format(str_py_files)
+    cmd = "pylint -d all -e missing-docstring {0}".format(str_py_files)
     output = bash(cmd).value().decode('utf-8')
 
     if 'rated' not in output:

--- a/captainhook/checkers/pylint_docstrings_checker.py
+++ b/captainhook/checkers/pylint_docstrings_checker.py
@@ -1,40 +1,8 @@
 # # # # # # # # # # # # # #
 # CAPTAINHOOK IDENTIFIER  #
 # # # # # # # # # # # # # #
-import re
-from .utils import bash, filter_python_files
+from .pylint_checker import *
 
 
-DEFAULT = 'off'
-CHECK_NAME = 'pylint_docstrings'
-NO_PYLINT_MSG = ("pylint is required for the pylint_docstrings plugin.\n"
-                "`pip install pylint` or turn it off in your tox.ini file.")
-SCORE = 85.0
-
-
-def run(files, temp_folder, arg=None):
-    "Check docstring coverage of the code base."
-    try:
-        import pylint
-    except ImportError:
-        return NO_PYLINT_MSG
-
-    # set default level of threshold
-    arg = arg or SCORE
-
-    py_files = filter_python_files(files)
-    if not py_files:
-        return False
-
-    str_py_files = " ".join(py_files)
-    cmd = "pylint -d all -e missing-docstring {0}".format(str_py_files)
-    output = bash(cmd).value().decode('utf-8')
-
-    if 'rated' not in output:
-        return False
-    score = float(re.search("(\d.\d\d)/10", output).group(1))
-    if score >= float(arg):
-        return False
-    return ("Pylint appreciated your docstrings as {0},"
-        "required threshold is {1}".format(score, arg)
-        )
+PYLINT_CMD = 'pylint -d all -e missing-docstring'
+PYLINT_TARGET = 'code'

--- a/captainhook/checkers/pylint_docstrings_checker.py
+++ b/captainhook/checkers/pylint_docstrings_checker.py
@@ -1,0 +1,41 @@
+# # # # # # # # # # # # # #
+# CAPTAINHOOK IDENTIFIER  #
+# # # # # # # # # # # # # #
+import re
+from .utils import bash, filter_python_files
+
+
+DEFAULT = 'off'
+CHECK_NAME = 'pylint_docstrings'
+NO_PYLINT_MSG = ("pylint is required for the pylint_docstrings plugin.\n"
+                "`pip install pylint` or turn it off in your tox.ini file.")
+SCORE = 85.0
+
+
+def run(files, temp_folder, arg=None):
+    "Check docstring coverage of the code base."
+    try:
+        import pylint
+    except ImportError:
+        return NO_PYLINT_MSG
+
+    # set default level of threshold
+    arg = arg or SCORE
+
+    py_files = filter_python_files(files)
+    if not py_files:
+        return False
+
+    str_py_files = " ".join(py_files)
+    cmd = "pylint -d all -e missing-docstring {0} | grep rated".format(str_py_files)
+    output = bash(cmd).value().decode('utf-8')
+    output = output.split()
+
+    if 'rated' not in output:
+        return False
+    score = float(re.search("(\d.\d\d)/10", output).group(1))
+    if score >= float(arg):
+        return False
+    return ("Pylint appreciated your docstrings as {0},"
+        "required threshold is {1}".format(score, arg)
+        )

--- a/captainhook/checkers/pylint_docstrings_checker.py
+++ b/captainhook/checkers/pylint_docstrings_checker.py
@@ -4,5 +4,9 @@
 from .pylint_checker import *
 
 
+DEFAULT = 'off'
+CHECK_NAME = 'pylint_docstrings'
+NO_PYLINT_MSG = ("pylint is required for the {0} plugin.\n"
+                "`pip install pylint` or turn it off in your tox.ini file.".format(CHECK_NAME))
 PYLINT_CMD = 'pylint -d all -e missing-docstring'
 PYLINT_TARGET = 'code'

--- a/captainhook/checkers/pylint_docstrings_checker.py
+++ b/captainhook/checkers/pylint_docstrings_checker.py
@@ -29,7 +29,6 @@ def run(files, temp_folder, arg=None):
     str_py_files = " ".join(py_files)
     cmd = "pylint -d all -e missing-docstring {0} | grep rated".format(str_py_files)
     output = bash(cmd).value().decode('utf-8')
-    output = output.split()
 
     if 'rated' not in output:
         return False

--- a/features/pylint_checker.feature
+++ b/features/pylint_checker.feature
@@ -1,0 +1,14 @@
+Feature: pylint checker
+
+    Background:
+        Given that I am in a git repository
+        And I have installed captainhook
+        And I have a tox.ini file with pylint=on
+
+    Scenario: When pylint are present the pylint checker raises an error when committing
+        When I create a file in "a" called "ignore.py" containing a line over 80 chars
+        And I git add "a/ignore.py"
+        And I git add "tox.ini"
+        And I attempt to commit
+        Then I see an error
+        And there are uncommitted changes

--- a/features/pylint_tox.feature
+++ b/features/pylint_tox.feature
@@ -1,0 +1,14 @@
+Feature: pylint obeys tox
+
+    Background:
+        Given that I am in a git repository
+        And I have installed captainhook
+        And I have a tox.ini file with pylint=on;0
+
+    Scenario: When a pylint section is present in tox.ini it should be obeyed.
+        When I create a file in "a" called "ignore.py" containing a line over 80 chars
+        And I git add "a/ignore.py"
+        And I git add "tox.ini"
+        And I attempt to commit
+        Then I see no errors
+        And there are no uncommitted changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ docopt==0.6.1
 flake8
 isort
 bash
-pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docopt==0.6.1
 flake8
 isort
 bash
+pylint

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 behave
 nose
 mock
+pylint


### PR DESCRIPTION
Optional checkers:
- execute `pylint file1 file2`
- execute `pylint -d all -e missing-docstring file1 file2`