### PR TITLE
Pep8radius checker

### DIFF
--- a/captainhook/checkers/pep8radius_checker.py
+++ b/captainhook/checkers/pep8radius_checker.py
@@ -1,0 +1,25 @@
+# # # # # # # # # # # # # #
+# CAPTAINHOOK IDENTIFIER  #
+# # # # # # # # # # # # # #
+from .utils import bash
+
+
+CHECK_NAME = 'pep8radius'
+DEFAULT = 'off'
+NO_PEP8RADIUS_MSG = (
+    "pep8radius is required for the pep8radius plugin.\n"
+    "`pip install pep8radius` or turn it off in your tox.ini file.")
+
+
+def run(files, temp_folder, argstring=''):
+    "Check PEP-8 errors, but only in the diff."
+
+    try:
+        import pep8radius  # NOQA
+    except ImportError:
+        return NO_PEP8RADIUS_MSG
+
+    return bash(
+        # Argument may contain unicode, i.e. in config file name.
+        u'pep8radius --diff --no-color {}'.format(argstring)
+    ).value()

--- a/captainhook/checkers/pep8radius_checker.py
+++ b/captainhook/checkers/pep8radius_checker.py
@@ -12,14 +12,22 @@ NO_PEP8RADIUS_MSG = (
 
 
 def run(files, temp_folder, argstring=''):
-    "Check PEP-8 errors, but only in the diff."
+    """Check PEP-8 errors, but only in the diff.
 
+    Arguments are passed verbatim to pep8radius.
+
+    See pep8radius on GitHub: https://github.com/hayd/pep8radius
+
+    """
     try:
         import pep8radius  # NOQA
     except ImportError:
         return NO_PEP8RADIUS_MSG
 
     return bash(
-        # Argument may contain unicode, i.e. in config file name.
+        # unicode because argument string may contain unicode,
+        # i.e. in config file name.
+        # --no-color because the color reset did not work when I tried it,
+        # screwing up the colors after the diff, too.
         u'pep8radius --diff --no-color {}'.format(argstring)
     ).value()


### PR DESCRIPTION
Check PEP-8 errors, but only in the diff.

```
Arguments are passed verbatim to pep8radius.

See pep8radius on GitHub: https://github.com/hayd/pep8radius
```

Addresses issue #95 
