### PR TITLE
[#94] isort checker now works with isort >=4.1.

### DIFF
--- a/captainhook/checkers/isort_checker.py
+++ b/captainhook/checkers/isort_checker.py
@@ -11,7 +11,12 @@ REQUIRED_FILES = ['.editorconfig', '.isort.cfg', 'setup.cfg']
 
 
 def run(files, temp_folder):
-    "Check isort errors in the code base."
+    """Check isort errors in the code base.
+
+    For the --quiet option, at least isort >= 4.1.1 is required.
+    https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#411
+
+    """
     try:
         import isort  # NOQA
     except ImportError:
@@ -19,4 +24,5 @@ def run(files, temp_folder):
 
     py_files = filter_python_files(files)
 
-    return bash('isort -df {0}'.format(' '.join(py_files))).value()
+    # --quiet because isort >= 4.1 outputs its logo in the console by default.
+    return bash('isort -df --quiet {0}'.format(' '.join(py_files))).value()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 docopt==0.6.1
 flake8
-isort
+# isort >= 4.1.1 because the isort checker requires the --quiet option.
+# https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#411
+isort>=4.1.1
 bash


### PR DESCRIPTION
isort 4.1 outputs it's logo by default, so we use the --quiet option added in 4.1.1's
to remove it again. Instead of supporting both any isort version, captainhook now
requires isort 4.1.1 for simplicity.

Resolves issue #94 .