### PR TITLE
Fix bug with blocked branch in Python 3

### DIFF
--- a/captainhook/checkers/block_branches.py
+++ b/captainhook/checkers/block_branches.py
@@ -13,7 +13,7 @@ def run(files, temp_folder, arg=None):
     parser = get_parser()
     argos = parser.parse_args(arg.split())
 
-    current_branch = bash('git symbolic-ref HEAD').value().decode('utf-8')
+    current_branch = bash('git symbolic-ref HEAD').value()
     current_branch = current_branch.replace('refs/heads/', '').strip()
     if current_branch in argos.branches:
         return ("Branch '{0}' is blocked from being "

--- a/test/test_checkers/test_block_branches.py
+++ b/test/test_checkers/test_block_branches.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals, absolute_import
+
+import unittest
+
+from mock import patch
+
+from captainhook.checkers import block_branches
+
+
+class TestMain(unittest.TestCase):
+
+    @patch('captainhook.checkers.block_branches.bash')
+    def test_run_none_blocked(self, bash):
+        bash_res = bash.return_value
+        bash_res.value.return_value = "master"
+        with self.assertRaises(AttributeError):
+            block_branches.run('something', '/tmp')
+
+    @patch('captainhook.checkers.block_branches.bash')
+    def test_run_single_blocked(self, bash):
+        bash_res = bash.return_value
+        bash_res.value.return_value = "master"
+        retval = block_branches.run('something', '/tmp', 'master')
+        self.assertEqual(retval, "Branch 'master' is blocked from being "
+                                 "committed to.")
+
+    @patch('captainhook.checkers.block_branches.bash')
+    def test_run_unblocked(self, bash):
+        bash_res = bash.return_value
+        bash_res.value.return_value = "staging"
+        retval = block_branches.run('something', '/tmp', 'master')
+        self.assertIsNone(retval)
+
+    @patch('captainhook.checkers.block_branches.bash')
+    def test_run_multi_blocked(self, bash):
+        bash_res = bash.return_value
+        bash_res.value.return_value = "staging"
+        retval = block_branches.run('something', '/tmp', 'master staging')
+        self.assertEqual(retval, "Branch 'staging' is blocked from being "
+                                 "committed to.")


### PR DESCRIPTION
Currently, the check to block branches doesn't work on Python 3:
```
Traceback (most recent call last):
[...]
  File "/.../captainhook/checkers/block_branches.py", line 16, in run
    current_branch = bash('git symbolic-ref HEAD').value().decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```
The value returned by bash.value() is already decoded as UTF-8.

In Python 2, all of this work:
```python
>>> b"test".decode('utf-8')
u'test'
>>> "test".decode('utf-8')
u'test'
>>> u"test".decode('utf-8')
u'test'
>>> "test".decode('utf-8').decode('utf-8')
u'test'
```

Whereas in Python 3:
```python
>>> b"test".decode('utf-8')
'test'
>>> "test".decode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
>>> b"test".decode('utf-8').decode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
```

- [x] Tests to reproduce the bug
- [x] Fix